### PR TITLE
Use the SiteDiscriminator of the StaticAsset when building resource name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,13 @@
         </dependency>
         <dependency>
             <groupId>org.broadleafcommerce</groupId>
+            <artifactId>broadleaf-contentmanagement-module</artifactId>
+            <version>${blc.version}</version>
+            <scope>compile</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.broadleafcommerce</groupId>
             <artifactId>broadleaf-third-party-integration-config</artifactId>
             <version>default</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <version>1.1.1-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>4.0.0-GA</blc.version>
+        <blc.version>4.0.9-SNAPSHOT</blc.version>
         <project.uri>${user.dir}</project.uri>
     </properties>
     <scm>
@@ -124,13 +124,6 @@
             <scope>compile</scope>
             <type>jar</type>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.broadleafcommerce</groupId>
-            <artifactId>broadleaf-contentmanagement-module</artifactId>
-            <version>${blc.version}</version>
-            <scope>compile</scope>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.broadleafcommerce</groupId>

--- a/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
+++ b/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
@@ -69,7 +69,7 @@ public abstract class AbstractS3Test {
 
             returnName = System.getProperty(propertyName);
             if (returnName == null) {
-                InputStream path = this.getClass().getResourceAsStream("/config/bc/amazon/common.properties");
+                InputStream path = this.getClass().getResourceAsStream("/config/bc/override/common.properties");
                 if (path != null) {
                     properties.load(path);
                 }

--- a/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
+++ b/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
@@ -69,7 +69,7 @@ public abstract class AbstractS3Test {
 
             returnName = System.getProperty(propertyName);
             if (returnName == null) {
-                InputStream path = this.getClass().getResourceAsStream("/config/bc/override/common.properties");
+                InputStream path = this.getClass().getResourceAsStream("/config/bc/amazon/common.properties");
                 if (path != null) {
                     properties.load(path);
                 }


### PR DESCRIPTION
- Addresses BroadleafCommerce/QA#1473
- tied to https://github.com/BroadleafCommerce/BroadleafCommercePrivate/pull/318
- also tied to https://github.com/BroadleafCommerce/MultiTenant-SingleSchema/pull/137
  <h3>Setup</h3>
  Install and configure Amazon module. 
  example of `common-shared.properties` used
  <b>**NOTE***</b> AWS has a problem with java 8; use java 7 when running AWS module

```
# Amazon
aws.s3.accessKeyId=(get a key)
aws.s3.secretKey=(get your own)
aws.s3.defaultBucketName=heatclinic
aws.s3.bucketSubDirectory=img
aws.s3.defaultBucketRegion=us-west-2
aws.s3.endpointURI=http://s3.amazonaws.com
```

<h2>Steps to recreate </h2>
1. Add a new image/media asset to a bundle1 on the template site (global.blc.dev )
2. promote and approve
3. delete the image from the temp directory: (example: mine was in /Library/apache-tomcat-7.0.54/temp/)
4. Go to the child site and try to view the product

<b>expected result:</b> Image should render 

<h2>Source of problem</h2>

Amazon module builds/generates an incorrect file path. In the above example, the image was placed at `bucket/img/site--1/newImage` but the child site attempted to retrieve it from path `bucket/img/site--3/newImage`. 

<h3> Solution </h3>

The system will first check the local filesystem for the static asset. If it does not find it locally, it will query the database for the corresponding `StaticAsset` object and use that to build the resource name expected by the S3 filesystem. 
