### PR TITLE
[DEVELOP-2.0.x] Add property to get credentials from EC2 instance.

### DIFF
--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3Configuration.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3Configuration.java
@@ -34,6 +34,7 @@ public class S3Configuration {
     private String defaultBucketRegion;
     private String endpointURI;
     private String bucketSubDirectory;
+    private Boolean useInstanceProfileCredentials;
 
     public String getAwsSecretKey() {
         return awsSecretKey;
@@ -83,6 +84,14 @@ public class S3Configuration {
         this.bucketSubDirectory = bucketSubDirectory;
     }
 
+    public Boolean getUseInstanceProfileCredentials() {
+        return useInstanceProfileCredentials;
+    }
+
+    public void setUseInstanceProfileCredentials(Boolean useInstanceProfileCredentials) {
+        this.useInstanceProfileCredentials = useInstanceProfileCredentials;
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
@@ -92,6 +101,7 @@ public class S3Configuration {
             .append(defaultBucketRegion)
             .append(endpointURI)
             .append(bucketSubDirectory)
+            .append(useInstanceProfileCredentials)
             .build();
     }
 
@@ -106,6 +116,7 @@ public class S3Configuration {
                 .append(this.getAWSAccessKeyId, that.getAWSAccessKeyId)
                 .append(this.endpointURI, that.endpointURI)
                 .append(this.bucketSubDirectory, that.bucketSubDirectory)
+                .append(this.useInstanceProfileCredentials, that.useInstanceProfileCredentials)
                 .build();
         }
         return false;

--- a/src/main/resources/config/bc/amazon/common.properties
+++ b/src/main/resources/config/bc/amazon/common.properties
@@ -18,6 +18,9 @@
 #Amazon AWS S3.   Used in blc-amazon module
 aws.s3.accessKeyId=
 aws.s3.secretKey=
+
+# Get credentials from instance if on EC2
+aws.s3.useInstanceProfile=false
 # The bucket name must be unique across all amazon S3 accounts (not just yours).   
 # An Error Code of "PermanentRedirect" can indicate that you need to choose another bucket name.
 #

--- a/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
+++ b/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
@@ -51,6 +51,7 @@ public abstract class AbstractS3Test {
         propService.setProperty("aws.s3.defaultBucketRegion", findProperty("aws.s3.defaultBucketRegion", "us-west-2"));
         propService.setProperty("aws.s3.endpointURI", findProperty("aws.s3.endpointURI", "https://s3.amazonaws.com"));
         propService.setProperty("aws.s3.bucketSubDirectory", findProperty("aws.s3.bucketSubDirectory", ""));
+        propService.setProperty("aws.s3.useInstanceProfile", findProperty("aws.s3.useInstanceProfile", "false"));
     }
 
     public static class TestSystemPropertiesService extends SystemPropertiesServiceImpl {

--- a/src/test/java/org/broadleafcommerce/vendor/amazon/s3/S3ConfigurationServiceTest.java
+++ b/src/test/java/org/broadleafcommerce/vendor/amazon/s3/S3ConfigurationServiceTest.java
@@ -84,4 +84,21 @@ public class S3ConfigurationServiceTest extends AbstractS3Test {
         }
         assertTrue("Expected to get an exception.", !ok);
     }
+
+    @Test
+    public void checkForMissingCredential() {
+        resetAllProperties();
+        propService.setProperty("aws.s3.useInstanceProfile", "false");
+        propService.setProperty("aws.s3.accessKeyId", "");
+        propService.setProperty("aws.s3.secretKey", "");
+
+        boolean ok;
+        try {
+            configService.lookupS3Configuration();
+            ok = true;
+        } catch (IllegalArgumentException iae) {
+            ok = false;
+        }
+        assertTrue("Exepected to get an exception.", !ok);
+    }
 }


### PR DESCRIPTION
When using the Amazon client from EC2, credentials can also be supplied from IAM roles. Adding that as an option in addition to secret key/access key.