### PR TITLE
Update AWS Java SDK, Add SSE option, Documentation

### DIFF
--- a/docs/Module-Installation.md
+++ b/docs/Module-Installation.md
@@ -1,4 +1,4 @@
-# Module Installation 
+# Module Installation
 The Broadleaf Amazon module requires [configuration](#configuration-changes) and [third-party property configuration](#third-party-property-configuration)
 
 ## Broadleaf Dependency
@@ -7,7 +7,7 @@ Version 1.1.0-GA requires Broadleaf 4.0 or later.
 
 ## Configuration Changes
 **Step 1.**  Add the dependency management section to your **parent** `pom.xml`:
-    
+
 ```xml
 <dependency>
     <groupId>org.broadleafcommerce</groupId>
@@ -19,7 +19,7 @@ Version 1.1.0-GA requires Broadleaf 4.0 or later.
 ```
 
 **Step 2.**  Add the dependency into your `core/pom.xml`:
-    
+
 ```xml
 <dependency>
     <groupId>org.broadleafcommerce</groupId>
@@ -44,26 +44,26 @@ classpath:/bl-amazon-applicationContext.xml
 
 
 ## Third Party Property Configuration
-This module requires you to configure properties specific to your amazon account.   
+This module requires you to configure properties specific to your amazon account.
 
 ### Amazon Credentials
 Broadleaf requires access to your Amazon AWS account.   See [About Amazon Credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for more information.
 
 **AccessKeyId / SecretKey**
 One approach for setting up credentials is to use an accessKeyId and secretKey.  When you create the access keys on amazon you will need to copy the values and add the following properties to your `common-shared.properties` file located in your core project.
- 
-aws.s3.accessKeyId=
 
-aws.s3.secretKey=
+    aws.s3.accessKeyId=
+
+    aws.s3.secretKey=
 
 **Instance Profiles**
 If you are hosting on EC2, you can now use Instance Profiles.  See [Creating Instance Profiles](http://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-create-iam-instance-profile.html)
 
 If you are using Instance Profiles, then the following property should be set:
 
-aws.s3.useInstanceProfile=true
+    aws.s3.useInstanceProfile=true
 
-### Amazon File Storage Location Information 
+### Amazon File Storage Location Information
 Broadleaf needs to know the specific location within your S3 account to store the files.   You will need to set the bucket name and the bucket location.  These properties are described on the [Amazon S3 Location Selection page](http://docs.aws.amazon.com/AmazonS3/latest/dev/LocationSelection.html).
 
 _The bucket name must be unique across all of Amazon_
@@ -83,5 +83,9 @@ _The Amazon module will default to the "us-west-2" region of S3. You can overrid
 _The Amazon module will default to utilize the default US endpoint "https://s3.amazonaws.com". You can override the endpoint with the following property:_
 
     aws.s3.endpointURI=https://s3.amazonaws.com
+
+_If your uploads require Server-Side Encryption, enable with this property. The default value is "false"._
+
+    aws.s3.sse=true
 
 

--- a/docs/Module-Installation.md
+++ b/docs/Module-Installation.md
@@ -47,12 +47,21 @@ classpath:/bl-amazon-applicationContext.xml
 This module requires you to configure properties specific to your amazon account.   
 
 ### Amazon Credentials
-Broadleaf requires access to your Amazon AWS account.   See [About Amazon Credentials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html) for more information on these two properties.  
+Broadleaf requires access to your Amazon AWS account.   See [About Amazon Credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for more information.
 
-When you create the access keys on amazon you will need to copy the values and add the following properties to your `common-shared.properties` file located in your core project.
+**AccessKeyId / SecretKey**
+One approach for setting up credentials is to use an accessKeyId and secretKey.  When you create the access keys on amazon you will need to copy the values and add the following properties to your `common-shared.properties` file located in your core project.
  
 aws.s3.accessKeyId=
+
 aws.s3.secretKey=
+
+**Instance Profiles**
+If you are hosting on EC2, you can now use Instance Profiles.  See [Creating Instance Profiles](http://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-create-iam-instance-profile.html)
+
+If you are using Instance Profiles, then the following property should be set:
+
+aws.s3.useInstanceProfile=true
 
 ### Amazon File Storage Location Information 
 Broadleaf needs to know the specific location within your S3 account to store the files.   You will need to set the bucket name and the bucket location.  These properties are described on the [Amazon S3 Location Selection page](http://docs.aws.amazon.com/AmazonS3/latest/dev/LocationSelection.html).

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <artifactId>broadleaf-amazon</artifactId>
     <name>BroadleafCommerce Amazon Integrations</name>
     <description>BroadleafCommerce Amazon Integrations</description>
-    <version>2.0.0-GA</version>
+    <version>2.0.1-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <blc.version>5.0.0-GA</blc.version>
@@ -27,7 +27,7 @@
         <connection>scm:git:git@github.com:BroadleafCommerce/blc-amazon.git</connection>
         <developerConnection>scm:git:git@github.com:BroadleafCommerce/blc-amazon.git</developerConnection>
         <url>https://github.com/BroadleafCommerce/blc-amazon</url>
-      <tag>broadleaf-amazon-2.0.0-GA</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <url>http://www.broadleafcommerce.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.6.7</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -115,6 +122,15 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.broadleafcommerce</groupId>
             <artifactId>broadleaf-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <artifactId>broadleaf-amazon</artifactId>
     <name>BroadleafCommerce Amazon Integrations</name>
     <description>BroadleafCommerce Amazon Integrations</description>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-GA</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <blc.version>5.0.0-GA</blc.version>
@@ -27,7 +27,8 @@
         <connection>scm:git:git@github.com:BroadleafCommerce/blc-amazon.git</connection>
         <developerConnection>scm:git:git@github.com:BroadleafCommerce/blc-amazon.git</developerConnection>
         <url>https://github.com/BroadleafCommerce/blc-amazon</url>
-    </scm>
+      <tag>broadleaf-amazon-2.0.0-GA</tag>
+  </scm>
 
     <url>http://www.broadleafcommerce.org</url>
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Copyright 2008-2009 the original author or authors. ~ ~ Licensed under the Apache License, Version 2.0 (the "License"); 
-    ~ you may not use this file except in compliance with the License. ~ You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 
-    ~ ~ Unless required by applicable law or agreed to in writing, software ~ distributed under the License is distributed on an 
-    "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. ~ See the License for the specific 
+<!-- ~ Copyright 2008-2009 the original author or authors. ~ ~ Licensed under the Apache License, Version 2.0 (the "License");
+    ~ you may not use this file except in compliance with the License. ~ You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0
+    ~ ~ Unless required by applicable law or agreed to in writing, software ~ distributed under the License is distributed on an
+    "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. ~ See the License for the specific
     language governing permissions and ~ limitations under the License. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -28,7 +28,7 @@
         <developerConnection>scm:git:git@github.com:BroadleafCommerce/blc-amazon.git</developerConnection>
         <url>https://github.com/BroadleafCommerce/blc-amazon</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <url>http://www.broadleafcommerce.org</url>
     <licenses>
@@ -84,7 +84,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <id>snapshots</id>
@@ -98,11 +98,22 @@
         </repository>
     </distributionManagement>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>1.11.170</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.9.27</version>
+            <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.broadleafcommerce</groupId>

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3Configuration.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3Configuration.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Class that holds the configuration for connecting to AmazonS3.
- * 
+ *
  * @author bpolster
  *
  */
@@ -35,6 +35,7 @@ public class S3Configuration {
     private String endpointURI;
     private String bucketSubDirectory;
     private Boolean useInstanceProfileCredentials;
+    private Boolean enableSSE;
 
     public String getAwsSecretKey() {
         return awsSecretKey;
@@ -67,7 +68,7 @@ public class S3Configuration {
     public void setDefaultBucketRegion(String defaultBucketRegion) {
         this.defaultBucketRegion = defaultBucketRegion;
     }
-        
+
     public String getEndpointURI() {
         return endpointURI;
     }
@@ -92,6 +93,14 @@ public class S3Configuration {
         this.useInstanceProfileCredentials = useInstanceProfileCredentials;
     }
 
+    public Boolean getEnableSSE() {
+        return enableSSE;
+    }
+
+    public void setEnableSSE(Boolean enableSSE) {
+        this.enableSSE = enableSSE;
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
@@ -102,6 +111,7 @@ public class S3Configuration {
             .append(endpointURI)
             .append(bucketSubDirectory)
             .append(useInstanceProfileCredentials)
+            .append(enableSSE)
             .build();
     }
 
@@ -117,6 +127,7 @@ public class S3Configuration {
                 .append(this.endpointURI, that.endpointURI)
                 .append(this.bucketSubDirectory, that.bucketSubDirectory)
                 .append(this.useInstanceProfileCredentials, that.useInstanceProfileCredentials)
+                .append(this.enableSSE, that.enableSSE)
                 .build();
         }
         return false;

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3ConfigurationServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3ConfigurationServiceImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -29,7 +29,7 @@ import javax.annotation.Resource;
 /**
  * Service that returns the an S3 configuration object.   Returns a configuration object with values
  * that are defined as system properties.
- * 
+ *
  * @author bpolster
  *
  */
@@ -38,7 +38,7 @@ public class S3ConfigurationServiceImpl implements S3ConfigurationService {
 
     @Resource(name = "blSystemPropertiesService")
     protected SystemPropertiesService systemPropertiesService;
-    
+
     @Override
     public S3Configuration lookupS3Configuration() {
         S3Configuration s3config = new S3Configuration();
@@ -49,6 +49,7 @@ public class S3ConfigurationServiceImpl implements S3ConfigurationService {
         s3config.setEndpointURI(lookupProperty("aws.s3.endpointURI"));
         s3config.setBucketSubDirectory(lookupProperty("aws.s3.bucketSubDirectory"));
         s3config.setUseInstanceProfileCredentials(Boolean.parseBoolean(lookupProperty("aws.s3.useInstanceProfile")));
+        s3config.setEnableSSE(Boolean.parseBoolean(lookupProperty("aws.s3.sse")));
 
         boolean accessSecretKeyBlank = StringUtils.isEmpty(s3config.getAwsSecretKey());
         boolean accessKeyIdBlank = StringUtils.isEmpty(s3config.getGetAWSAccessKeyId());
@@ -56,7 +57,7 @@ public class S3ConfigurationServiceImpl implements S3ConfigurationService {
         boolean useInstanceProfile = s3config.getUseInstanceProfileCredentials();
         Region region = RegionUtils.getRegion(s3config.getDefaultBucketRegion());
         boolean canRetrieveCredentials = !(accessSecretKeyBlank || accessKeyIdBlank) || useInstanceProfile;
-        
+
         if (region == null || !canRetrieveCredentials || bucketNameBlank) {
             StringBuilder errorMessage = new StringBuilder("Amazon S3 Configuration Error : ");
 

--- a/src/main/resources/config/bc/amazon/common.properties
+++ b/src/main/resources/config/bc/amazon/common.properties
@@ -10,7 +10,7 @@
 # the Broadleaf End User License Agreement (EULA), Version 1.1
 # (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
 # shall apply.
-# 
+#
 # Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
 # between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
 # #L%
@@ -21,10 +21,14 @@ aws.s3.secretKey=
 
 # Get credentials from instance if on EC2
 aws.s3.useInstanceProfile=false
-# The bucket name must be unique across all amazon S3 accounts (not just yours).   
+
+# Enable or disable server side encryption for S3 Uploads
+aws.s3.sse=false
+
+# The bucket name must be unique across all amazon S3 accounts (not just yours).
 # An Error Code of "PermanentRedirect" can indicate that you need to choose another bucket name.
 #
-# To ensure your bucketName is unique, create it via S3 before updating your property file. 
+# To ensure your bucketName is unique, create it via S3 before updating your property file.
 
 aws.s3.defaultBucketName=
 aws.s3.defaultBucketRegion=us-west-2

--- a/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
+++ b/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -29,8 +29,8 @@ import java.io.InputStream;
 import java.util.Properties;
 
 /**
- * Tests that error messages are returned for misconfigured amazon s3 properties. 
- * 
+ * Tests that error messages are returned for misconfigured amazon s3 properties.
+ *
  * @author bpolster
  */
 public abstract class AbstractS3Test {
@@ -43,7 +43,7 @@ public abstract class AbstractS3Test {
         CacheManager.getInstance().addCacheIfAbsent("blSystemPropertyElements");
         configService.setSystemPropertiesService(propService);
     }
-    
+
     protected void resetAllProperties() {
         propService.setProperty("aws.s3.accessKeyId", findProperty("aws.s3.accessKeyId", "testKeyId"));
         propService.setProperty("aws.s3.secretKey", findProperty("aws.s3.secretKey", "secretKey"));
@@ -52,6 +52,7 @@ public abstract class AbstractS3Test {
         propService.setProperty("aws.s3.endpointURI", findProperty("aws.s3.endpointURI", "https://s3.amazonaws.com"));
         propService.setProperty("aws.s3.bucketSubDirectory", findProperty("aws.s3.bucketSubDirectory", ""));
         propService.setProperty("aws.s3.useInstanceProfile", findProperty("aws.s3.useInstanceProfile", "false"));
+        propService.setProperty("aws.s3.sse", findProperty("aws.s3.sse", "false"));
     }
 
     public static class TestSystemPropertiesService extends SystemPropertiesServiceImpl {


### PR DESCRIPTION
Hey Guys,
We implemented this in our fork to get it working for our environment. Contributing it back.

* Updated the Java SDK to 1.11.x 
* Added option for server side encryption for S3 uploads
* Updated documentation for sse option and general spacing

Note: I also had to update the Jackson version because Maven was choosing the current version from the BLC bom but the AWS SDK needs the newer version. Should resolve #11 .
The AmazonS3Client interface has also been deprecated but including that upgrade here would be too much in one PR.