### PR TITLE
Image corruption can occur when multiple treatments for the same image are requested concurrently

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.9.27</version>
+            <version>1.11.228</version>
         </dependency>
         <dependency>
             <groupId>org.broadleafcommerce</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <version>2.0.1-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>5.0.0-GA</blc.version>
+        <blc.version>5.0.14-SNAPSHOT</blc.version>
         <project.uri>${user.dir}</project.uri>
     </properties>
     <scm>

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProvider.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProvider.java
@@ -25,6 +25,7 @@ import org.broadleafcommerce.common.file.domain.FileWorkArea;
 import org.broadleafcommerce.common.file.service.BroadleafFileService;
 import org.broadleafcommerce.common.file.service.FileServiceProvider;
 import org.broadleafcommerce.common.file.service.type.FileApplicationType;
+import org.broadleafcommerce.common.io.ConcurrentFileOutputStream;
 import org.broadleafcommerce.common.site.domain.Site;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.springframework.stereotype.Service;
@@ -39,10 +40,8 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -70,7 +69,10 @@ public class S3FileServiceProvider implements FileServiceProvider {
 
     @Resource(name = "blFileService")
     protected BroadleafFileService blFileService;
-    
+
+    @Resource(name = "blConcurrentFileOutputStream")
+    protected ConcurrentFileOutputStream concurrentFileOutputStream;
+
     protected Map<S3Configuration, AmazonS3Client> configClientMap = new HashMap<S3Configuration, AmazonS3Client>();
 
     @Override
@@ -81,7 +83,6 @@ public class S3FileServiceProvider implements FileServiceProvider {
     @Override
     public File getResource(String name, FileApplicationType fileApplicationType) {
         File returnFile = blFileService.getLocalResource(buildResourceName(name));
-        OutputStream outputStream = null;
         InputStream inputStream = null;
 
         try {
@@ -99,13 +100,9 @@ public class S3FileServiceProvider implements FileServiceProvider {
                     }
                 }
             }
-            outputStream = new FileOutputStream(returnFile);
-            int read = 0;
-            byte[] bytes = new byte[1024];
 
-            while ((read = inputStream.read(bytes)) != -1) {
-                outputStream.write(bytes, 0, read);
-            }
+            concurrentFileOutputStream.write(inputStream, returnFile, 1024);
+
         } catch (IOException ioe) {
             throw new RuntimeException("Error writing s3 file to local file system", ioe);
         } catch (AmazonS3Exception s3Exception) {
@@ -121,14 +118,6 @@ public class S3FileServiceProvider implements FileServiceProvider {
                 } catch (IOException e) {
                     throw new RuntimeException("Error closing input stream while writing s3 file to file system", e);
                 }
-            }
-            if (outputStream != null) {
-                try {
-                    outputStream.close();
-                } catch (IOException e) {
-                    throw new RuntimeException("Error closing output stream while writing s3 file to file system", e);
-                }
-
             }
         }
         return returnFile;


### PR DESCRIPTION
BroadleafCommerce/QA#3094
use ConcurrentFileOutputStream component to write file
