### PR TITLE
Image corruption can occur when multiple treatments for the same image are requested concurrently

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <version>1.1.2-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>4.0.0-GA</blc.version>
+        <blc.version>4.0.24-SNAPSHOT</blc.version>
         <project.uri>${user.dir}</project.uri>
     </properties>
     <scm>

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProvider.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProvider.java
@@ -262,4 +262,7 @@ public class S3FileServiceProvider implements FileServiceProvider {
         this.blFileService = bfs;
     }
 
+    public void setConcurrentFileOutputStream(ConcurrentFileOutputStream concurrentFileOutputStream) {
+        this.concurrentFileOutputStream = concurrentFileOutputStream;
+    }
 }

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProvider.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProvider.java
@@ -26,6 +26,7 @@ import org.broadleafcommerce.common.file.domain.FileWorkArea;
 import org.broadleafcommerce.common.file.service.BroadleafFileService;
 import org.broadleafcommerce.common.file.service.FileServiceProvider;
 import org.broadleafcommerce.common.file.service.type.FileApplicationType;
+import org.broadleafcommerce.common.io.ConcurrentFileOutputStream;
 import org.broadleafcommerce.common.site.domain.Site;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.springframework.stereotype.Service;
@@ -40,10 +41,8 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -73,6 +72,9 @@ public class S3FileServiceProvider implements FileServiceProvider {
     
     protected Map<S3Configuration, AmazonS3Client> configClientMap = new HashMap<S3Configuration, AmazonS3Client>();
 
+    @Resource(name = "blConcurrentFileOutputStream")
+    protected ConcurrentFileOutputStream concurrentFileOutputStream;
+
     @Override
     public File getResource(String name) {
         return getResource(name, FileApplicationType.ALL);
@@ -81,7 +83,6 @@ public class S3FileServiceProvider implements FileServiceProvider {
     @Override
     public File getResource(String name, FileApplicationType fileApplicationType) {
         File returnFile = blFileService.getLocalResource(buildResourceName(name));
-        OutputStream outputStream = null;
         InputStream inputStream = null;
 
         try {
@@ -99,13 +100,9 @@ public class S3FileServiceProvider implements FileServiceProvider {
                     }
                 }
             }
-            outputStream = new FileOutputStream(returnFile);
-            int read = 0;
-            byte[] bytes = new byte[1024];
 
-            while ((read = inputStream.read(bytes)) != -1) {
-                outputStream.write(bytes, 0, read);
-            }
+            concurrentFileOutputStream.write(inputStream, returnFile);
+
         } catch (IOException ioe) {
             throw new RuntimeException("Error writing s3 file to local file system", ioe);
         } catch (AmazonS3Exception s3Exception) {
@@ -121,14 +118,6 @@ public class S3FileServiceProvider implements FileServiceProvider {
                 } catch (IOException e) {
                     throw new RuntimeException("Error closing input stream while writing s3 file to file system", e);
                 }
-            }
-            if (outputStream != null) {
-                try {
-                    outputStream.close();
-                } catch (IOException e) {
-                    throw new RuntimeException("Error closing output stream while writing s3 file to file system", e);
-                }
-
             }
         }
         return returnFile;

--- a/src/test/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProviderTest.java
+++ b/src/test/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProviderTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.file.domain.FileWorkArea;
 import org.broadleafcommerce.common.file.service.BroadleafFileServiceExtensionManager;
 import org.broadleafcommerce.common.file.service.BroadleafFileServiceImpl;
+import org.broadleafcommerce.common.io.ConcurrentFileOutputStreamImpl;
 import org.broadleafcommerce.common.site.domain.SiteImpl;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.junit.BeforeClass;
@@ -76,11 +77,19 @@ public class S3FileServiceProviderTest extends AbstractS3Test {
             extensionManager = new BroadleafFileServiceExtensionManager();
         }
     }
-    
+
+    public class MockConcurrentFileOutputStream extends ConcurrentFileOutputStreamImpl {
+        public MockConcurrentFileOutputStream() {
+            defaultFileBufferSize = 8192;
+        }
+    }
+
     @BeforeClass
     public static void setupProvider() {
         s3FileProvider.s3ConfigurationService = configService;
-        s3FileProvider.setBroadleafFileService(new S3FileServiceProviderTest().new S3BroadleafFileService());
+        S3FileServiceProviderTest testFileServiceProvider = new S3FileServiceProviderTest();
+        s3FileProvider.setBroadleafFileService(testFileServiceProvider.new S3BroadleafFileService());
+        s3FileProvider.setConcurrentFileOutputStream(testFileServiceProvider.new MockConcurrentFileOutputStream());
     }
 
     @Test


### PR DESCRIPTION
BroadleafCommerce/QA#3094
write file using ConcurrentFileOutputStream
Requires BroadleafCommerce/BroadleafCommerce#1746