### PR TITLE
Add Container Credentials to available S3 authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,30 @@ Fulfillment : Roadmap Item
         classpath:/bl-amazon-applicationContext.xml
     ```
     > Note: This line should go before the `classpath:/applicationContext.xml` line
+
+## Steps to configure this module
+
+There are several login mechanisms that can be used in AWS.
+
+Configuration can be done by setting specific variables in `common.properties`. Three credentials mechanisms from the ![AWS credentials chain](https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html) are available for usage and configuration.
+
+### Amazon AWS S3 Key + Secret Authentication
+
+```
+aws.s3.accessKeyId=
+aws.s3.secretKey=
+```
+
+### EC2 Instance Profile Authentication
+
+```
+aws.s3.useInstanceProfile=true
+```
+
+### ECS or Fargate Container Authentication 
+
+Note that EC2 Instance Profile Authentication has precedence over ECS and Fargate. If both are set to true, Container Credentials will be ignored.
+
+```
+aws.s3.useContainerCredentials=true
+```

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.broadleafcommerce</groupId>
         <artifactId>broadleaf-module-parent</artifactId>
-        <version>3.0.0-GA</version>
+        <version>3.0.2-GA</version>
     </parent>
 
     <groupId>org.broadleafcommerce</groupId>

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3Configuration.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3Configuration.java
@@ -131,6 +131,7 @@ public class S3Configuration {
             .append(endpointURI)
             .append(bucketSubDirectory)
             .append(useInstanceProfileCredentials)
+            .append(useContainerCredentials)
             .append(enableSSE)
             .build();
     }
@@ -147,6 +148,7 @@ public class S3Configuration {
                 .append(this.endpointURI, that.endpointURI)
                 .append(this.bucketSubDirectory, that.bucketSubDirectory)
                 .append(this.useInstanceProfileCredentials, that.useInstanceProfileCredentials)
+                .append(this.useContainerCredentials, that.useContainerCredentials)
                 .append(this.enableSSE, that.enableSSE)
                 .build();
         }

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3Configuration.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3Configuration.java
@@ -40,6 +40,7 @@ public class S3Configuration {
     private String endpointURI;
     private String bucketSubDirectory;
     private Boolean useInstanceProfileCredentials;
+    private Boolean useContainerCredentials;
     private Boolean enableSSE;
 
     public String getAwsSecretKey() {
@@ -105,6 +106,12 @@ public class S3Configuration {
     public void setUseInstanceProfileCredentials(Boolean useInstanceProfileCredentials) {
         this.useInstanceProfileCredentials = useInstanceProfileCredentials;
     }
+
+    public void setUseContainerCredentials(Boolean useContainerCredentials) {
+        this.useContainerCredentials = useContainerCredentials;
+    }
+
+    public Boolean getUseContainerCredentials() { return useContainerCredentials; }
 
     public Boolean getEnableSSE() {
         return enableSSE;

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3ConfigurationServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3ConfigurationServiceImpl.java
@@ -49,14 +49,16 @@ public class S3ConfigurationServiceImpl implements S3ConfigurationService {
         s3config.setEndpointURI(lookupProperty("aws.s3.endpointURI"));
         s3config.setBucketSubDirectory(lookupProperty("aws.s3.bucketSubDirectory"));
         s3config.setUseInstanceProfileCredentials(Boolean.parseBoolean(lookupProperty("aws.s3.useInstanceProfile")));
+        s3config.setUseContainerCredentials(Boolean.parseBoolean(lookupProperty("aws.s3.useContainerProfile")));
         s3config.setEnableSSE(Boolean.parseBoolean(lookupProperty("aws.s3.sse")));
 
         boolean accessSecretKeyBlank = StringUtils.isEmpty(s3config.getAwsSecretKey());
         boolean accessKeyIdBlank = StringUtils.isEmpty(s3config.getGetAWSAccessKeyId());
         boolean bucketNameBlank = StringUtils.isEmpty(s3config.getDefaultBucketName());
         boolean useInstanceProfile = s3config.getUseInstanceProfileCredentials();
+        boolean useContainerCredentials = s3config.getUseContainerCredentials();
         Region region = RegionUtils.getRegion(s3config.getDefaultBucketRegion());
-        boolean canRetrieveCredentials = !(accessSecretKeyBlank || accessKeyIdBlank) || useInstanceProfile;
+        boolean canRetrieveCredentials = !(accessSecretKeyBlank || accessKeyIdBlank) || useInstanceProfile || useContainerCredentials;
 
         if (region == null || !canRetrieveCredentials || bucketNameBlank) {
             StringBuilder errorMessage = new StringBuilder("Amazon S3 Configuration Error : ");
@@ -75,6 +77,10 @@ public class S3ConfigurationServiceImpl implements S3ConfigurationService {
 
             if (!useInstanceProfile) {
                 errorMessage.append("aws.s3.useInstanceProfile was blank or false,");
+            }
+
+            if (!useContainerCredentials) {
+                errorMessage.append("aws.s3.useContainerCredentials was blank or false,");
             }
 
             if (region == null) {

--- a/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProvider.java
+++ b/src/main/java/org/broadleafcommerce/vendor/amazon/s3/S3FileServiceProvider.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 
 import javax.annotation.Resource;
 
+import com.amazonaws.auth.ContainerCredentialsProvider;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -340,6 +341,9 @@ public class S3FileServiceProvider implements FileServiceProvider {
         if(s3config.getUseInstanceProfileCredentials()) {
             builder = AmazonS3ClientBuilder.standard()
                     .withCredentials(new InstanceProfileCredentialsProvider(false));
+        } else if(s3config.getUseContainerCredentials()) {
+            builder = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new ContainerCredentialsProvider());
         } else {
             builder = AmazonS3ClientBuilder.standard()
                     .withCredentials(new AWSStaticCredentialsProvider(getAWSCredentials(s3config)));

--- a/src/main/resources/config/bc/amazon/common.properties
+++ b/src/main/resources/config/bc/amazon/common.properties
@@ -22,6 +22,9 @@ aws.s3.secretKey=
 # Get credentials from instance if on EC2
 aws.s3.useInstanceProfile=false
 
+# Get credentials from instance if on ECS or Fargate
+aws.s3.useContainerCredentials=false
+
 # Enable or disable server side encryption for S3 Uploads
 aws.s3.sse=false
 

--- a/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
+++ b/src/test/java/org/broadleafcommerce/vendor/amazon/s3/AbstractS3Test.java
@@ -58,6 +58,7 @@ public abstract class AbstractS3Test {
         propService.setProperty("aws.s3.endpointURI", findProperty("aws.s3.endpointURI", "https://s3.amazonaws.com"));
         propService.setProperty("aws.s3.bucketSubDirectory", findProperty("aws.s3.bucketSubDirectory", ""));
         propService.setProperty("aws.s3.useInstanceProfile", findProperty("aws.s3.useInstanceProfile", "false"));
+        propService.setProperty("aws.s3.useContainerProfile", findProperty("aws.s3.useContainerProfile", "false"));
         propService.setProperty("aws.s3.sse", findProperty("aws.s3.sse", "false"));
     }
 


### PR DESCRIPTION
- Adds the ability to use Container Credentials S3 authentication for ECS or Fargate environments.

**A Brief Overview**
- Read configuration
- Additional option for Authentication
- Readme updates